### PR TITLE
Apply BasePlugin before using `check` task

### DIFF
--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -7,6 +7,7 @@ package kotlinx.knit
 import org.apache.log4j.*
 import org.gradle.api.*
 import org.gradle.api.file.*
+import org.gradle.api.plugins.*
 import org.gradle.api.tasks.*
 import java.io.*
 
@@ -15,6 +16,7 @@ const val DEPENDENCY_GROUP = "org.jetbrains.kotlinx"
 
 class KnitPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = with(project) {
+        pluginManager.apply(BasePlugin::class.java)
         // Create tasks
         extensions.create("knit", KnitPluginExtension::class.java)
         val knitPrepare = tasks.register("knitPrepare", DefaultTask::class.java) {


### PR DESCRIPTION
I tried to apply the `kotlinx-knit` plugin in the gradle plugins block but it didn't work, even though I applied the `base` plugin. Unfortunately the `kotlinx-knit` was applied first. Because of this, there was no `check` task which could depend on the `knitCheck` task.
With this addition the build process worked.