### PR TITLE
Fixed dependency of check task on knitCheck task

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Knit plugin registers the following tasks:
 
 * `knit` &mdash; updates markdown files, samples, and tests.
 * `knitCheck` &mdash; checks that all the files are up-to-date and fail the build if not;
-  it is automatically added as dependency to `check` task and thus is performed on `build`.
+  it is automatically added as dependency to `check` task and thus is performed on `build` if the `base` plugin is applied.
 * `knitPrepare` &mdash; does nothing, but is added as a dependency to both `knit` and `knitCheck` and a
   common place to register all prerequisite tasks like `dokka` (see [Dokka setup](#dokka-setup))    
 

--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -51,12 +51,9 @@ class KnitPlugin : Plugin<Project> {
 }
 
 private fun Project.checkDependsOn(other: TaskProvider<*>) {
-    afterEvaluate {
-        // afterEvaluate because the order of plugin application does not reflect declaration order in some Gradle versions
-        if (pluginManager.hasPlugin("base")) {
-            tasks.named("check").configure {
-                it.dependsOn(other)
-            }
+    pluginManager.withPlugin("base") {
+        tasks.named("check").configure {
+            it.dependsOn(other)
         }
     }
 }

--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -18,7 +18,7 @@ class KnitPlugin : Plugin<Project> {
         // Create tasks
         extensions.create("knit", KnitPluginExtension::class.java)
         val knitPrepare = tasks.register("knitPrepare", DefaultTask::class.java) {
-            it.description =  "Prepares dependencies for Knit tool"
+            it.description = "Prepares dependencies for Knit tool"
             it.group = TASK_GROUP
         }
         val knitCheck = tasks.register("knitCheck", KnitTask::class.java) {
@@ -32,9 +32,7 @@ class KnitPlugin : Plugin<Project> {
             it.group = TASK_GROUP
             it.dependsOn(knitPrepare)
         }
-        tasks.named("check").configure {
-            it.dependsOn(knitCheck)
-        }
+        checkDependsOn(knitCheck)
         // Configure default version resolution for 'kotlinx-knit-test'
         val pluginVersion = rootProject.buildscript.configurations.findByName("classpath")
             ?.allDependencies?.find { it.group == DEPENDENCY_GROUP && it.name == "kotlinx-knit" }?.version
@@ -47,6 +45,17 @@ class KnitPlugin : Plugin<Project> {
                         dependency.useVersion(pluginVersion)
                     }
                 }
+            }
+        }
+    }
+}
+
+private fun Project.checkDependsOn(other: TaskProvider<*>) {
+    afterEvaluate {
+        // afterEvaluate because the order of plugin application does not reflect declaration order in some Gradle versions
+        if (pluginManager.hasPlugin("base")) {
+            tasks.named("check").configure {
+                it.dependsOn(other)
             }
         }
     }
@@ -98,7 +107,7 @@ open class KnitPluginExtension {
             siteRoot = siteRoot,
             moduleRoots = moduleRoots,
             moduleMarkers = moduleMarkers,
-            moduleDocs =  moduleDocs,
+            moduleDocs = moduleDocs,
             dokkaMultiModuleRoot = dokkaMultiModuleRoot
         ),
         files = files,


### PR DESCRIPTION
Applying the plugin in a plugins block was not possible because the `base` plugin is applied afterwards in some Gradle versions (even if it was declared before).

This is an alternative solution to #22 which does not apply the `base` plugin under the hood. In fact, it is not anymore necessary at all to apply the `base` plugin.