### PR TITLE
Updated documentation for latest release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log for kotlinx-knit
 
+## Version 0.3.0
+
+* Support new Dokka multi-module structure.
+
 ## Version 0.2.3
 
 * Additional newlines are added between `INDEX` directives.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![JetBrains incubator project](https://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![Apache license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Download](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-knit/0.2.2)](https://search.maven.org/artifact/org.jetbrains.kotlinx/kotlinx-knit/0.2.2/pom)
+[![Download](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-knit?versionPrefix=0.3&versionSuffix=.0)](https://search.maven.org/artifact/org.jetbrains.kotlinx/kotlinx-knit/0.3.0/pom)
 
 Kotlin source code documentation management tool.
 
@@ -73,7 +73,7 @@ Add it to the `build.gradle` in the following way:
 ```groovy        
 buildscript {
     dependencies {
-        classpath "org.jetbrains.kotlinx:kotlinx-knit:0.2.3"
+        classpath "org.jetbrains.kotlinx:kotlinx-knit:0.3.0"
     }
 }
                     


### PR DESCRIPTION
Some changes in documentation have been forgotten for the `0.3.0` release.

- [ ] Could you also please tag the released commit so that the `0.3.0` release is shown on the GitHub releases page?