### PR TITLE
Retain line separators when generating files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ knit {
         exclude '**/build/**'
         exclude '**/.gradle/**'
     }
-    defaultLineSeparator = System.lineSeparator() // line separator used for newly generated files
+    defaultLineSeparator = '\n' // line separator used for newly generated files
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ knit {
         exclude '**/build/**'
         exclude '**/.gradle/**'
     }
+    defaultLineSeparator = System.lineSeparator() // line separator used for newly generated files
 }
 ```
 

--- a/src/Knit.kt
+++ b/src/Knit.kt
@@ -679,11 +679,18 @@ private fun formatOutdated(oldLines: List<String>?, outLines: List<String>) =
         "is not up-to-date, $diff"
     }
 
-fun KnitContext.writeLines(file: File, lines: List<String>) {
-    log.info(" Writing $file ...")
+private fun KnitContext.writeLines(file: File, lines: List<String>) {
+    val lineSep = if (file.exists()) {
+        file.bufferedReader().use {
+            it.firstLineSeparator()
+        } ?: lineSeparator
+    } else {
+        lineSeparator
+    }
+    log.info("Writing $file ...")
     file.parentFile?.mkdirs()
-    file.printWriter().use { out ->
-        lines.forEach { out.println(it) }
+    file.bufferedWriter().use { out ->
+        lines.forEach { out.write("$it$lineSep") }
     }
 }
 

--- a/src/KnitContext.kt
+++ b/src/KnitContext.kt
@@ -38,6 +38,7 @@ class KnitContext(
     // files to process
     files: Collection<File>,
     val rootDir: File,
+    val lineSeparator: String,
     val check: Boolean
 ) : KnitGlobals(globals) {
     // state

--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -109,16 +109,17 @@ open class KnitPluginExtension {
     )
 
     private fun evaluateLineSeparator(): String {
+        val unix = "\n"
+        val windows = "\r\n"
         val ls = defaultLineSeparator
-        if (ls != null && ls != "\n" && ls != "\r\n" && ls != "\r") {
+        if (ls != null && ls != unix && ls != windows) {
             throw GradleException(
                 """Knit defaultLineSeparator must be one of:
                 |- Unix (\n)
                 |- Windows (\r\n)
-                |- Classic Mac OS (\r)
             """.trimMargin()
             )
         }
-        return ls ?: System.lineSeparator()
+        return ls ?: unix
     }
 }

--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -91,6 +91,7 @@ open class KnitPluginExtension {
     var files: FileCollection? = null
     var rootDir: File? = null
     var dokkaMultiModuleRoot: String = globalDefaults.dokkaMultiModuleRoot
+    var defaultLineSeparator: String? = null
 
     fun createContext(files: Collection<File>, rootDir: File, check: Boolean) = KnitContext(
         log = LoggerLog(),
@@ -103,6 +104,21 @@ open class KnitPluginExtension {
         ),
         files = files,
         rootDir = rootDir,
+        lineSeparator = evaluateLineSeparator(),
         check = check
     )
+
+    private fun evaluateLineSeparator(): String {
+        val ls = defaultLineSeparator
+        if (ls != null && ls != "\n" && ls != "\r\n" && ls != "\r") {
+            throw GradleException(
+                """Knit defaultLineSeparator must be one of:
+                |- Unix (\n)
+                |- Windows (\r\n)
+                |- Classic Mac OS (\r)
+            """.trimMargin()
+            )
+        }
+        return ls ?: System.lineSeparator()
+    }
 }

--- a/src/KnitProps.kt
+++ b/src/KnitProps.kt
@@ -26,7 +26,7 @@ fun createDefaultContext(
         globals = globals,
         files = files,
         rootDir = File(System.getProperty("user.dir")),
-        lineSeparator = System.lineSeparator(),
+        lineSeparator = "\n",
         check = false
     )
 }

--- a/src/KnitProps.kt
+++ b/src/KnitProps.kt
@@ -26,6 +26,7 @@ fun createDefaultContext(
         globals = globals,
         files = files,
         rootDir = File(System.getProperty("user.dir")),
+        lineSeparator = System.lineSeparator(),
         check = false
     )
 }

--- a/src/KnitUtil.kt
+++ b/src/KnitUtil.kt
@@ -20,3 +20,21 @@ fun <T : LineNumberReader> KnitContext.withLineNumberReader(file: File, factory:
 }
 
 operator fun File.div(path: String): File = File(this, path.replace("/", File.separator))
+
+internal fun Reader.firstLineSeparator(): String? {
+    val n = '\n'.toInt()
+    val r = '\r'.toInt()
+    while (true) {
+        val current = read()
+        if (current == -1) {
+            return null
+        } else if (current == n || current == r) {
+            var result = current.toChar().toString()
+            val next = read()
+            if (current == r && next == n) {
+                result += next.toChar().toString()
+            }
+            return result
+        }
+    }
+}

--- a/test/KnitUtilTest.kt
+++ b/test/KnitUtilTest.kt
@@ -1,0 +1,24 @@
+package kotlinx.knit
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class KnitUtilTest {
+    @Test
+    fun testFirstLineSeparator() {
+        mapOf(
+            "" to null,
+            "\n" to "\n",
+            "\r" to "\r",
+            "\r\n" to "\r\n",
+            "\n\r" to "\n",
+            "abc" to null,
+            "abc\n" to "\n",
+            "abc\r\n" to "\r\n",
+            "abc\nxyz\r" to "\n",
+            "abc\r\nxyz\n\r" to "\r\n"
+        ).forEach { (input, expected) ->
+            assertEquals(expected, input.reader().firstLineSeparator())
+        }
+    }
+}


### PR DESCRIPTION
Nowadays it is standard to work on projects with Unix line endings even under Windows. However, Knit always uses the default system line separator when writing files. This also implies that it always changes the line endings of files whenever it has to update them and the original line ending differs from the system default. This is quite annoying in the aforementioned situation.

This PR offers the following enhancements:
* Line endings are preserved when the file already exists.
* A new property `defaultLineSeparator` (with `System.lineSeparator()` as default) in the `knit` extension allows to specify the line separator which shall be used when new files are written.