### PR TITLE
Fix massive performance degradation for whole Gradle build

### DIFF
--- a/src/KnitPlugin.kt
+++ b/src/KnitPlugin.kt
@@ -58,16 +58,20 @@ open class KnitTask : DefaultTask() {
     @Input
     var check: Boolean = false
 
-    @InputDirectory
+    @Internal
     var rootDir: File = ext.rootDir ?: project.rootDir
 
-    @InputFiles
+    @Internal
     var files: FileCollection = ext.files ?: project.fileTree(project.rootDir) {
         it.include("**/*.md")
         it.include("**/*.kt")
         it.include("**/*.kts")
         it.exclude("**/build/*")
         it.exclude("**/.gradle/*")
+    }
+
+    init {
+        outputs.upToDateWhen { false }
     }
 
     @TaskAction


### PR DESCRIPTION
Especially when switching to Gradle 7, Gradle disables execution optimization (up-to-date checks) for many tasks (e.g. compileKotlin) because they produce files which are registered as input for the knit/knitCheck tasks. The message from Gradle is something like this (see also #30):

> Execution optimizations have been disabled for task '...' to ensure correctness due to the following reasons:
> Gradle detected a problem with the following location: '...'. Reason: Task ':knitCheck' uses this output of task '...' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

The problem is that `KnitTask` registers the `rootDir` as input directory, the latter being the whole Gradle project by default, including all build folders. This interfers usually with any task producing something in the build folders.

On the other hand, `KnitTask` does not have any outputs registered. So up-to-date checking for tasks of this type never was enabled. It is also not relevant for the knit/knitCheck tasks.

The solution simply was to remove the input annotations from the task properties and to explicitly disable the up-to-date feature (in the init block) for documentation purposes and for deriving task classes.