### PR TITLE
Update Dokka to 1.9.10 and Kotlin to 1.9.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     gradlePluginPortal()
 }
 
@@ -26,7 +25,6 @@ allprojects {
     apply(plugin = "org.gradle.maven-publish")
 
     repositories {
-        jcenter()
         mavenCentral()
     }
 
@@ -35,6 +33,11 @@ allprojects {
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.1")
         implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1")
         testImplementation(kotlin("test-junit"))
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     
     tasks.withType<KotlinCompile> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 # Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
 
-version=0.5.0-Beta-SNAPSHOT
+version=0.5.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.8.10
-dokkaVersion=1.8.10
+kotlinVersion=1.9.21
+dokkaVersion=1.9.10
 freemarkerVersion=2.3.29
 pluginPublishVersion=0.15.0


### PR DESCRIPTION
Fixes updating coroutines and serialization to latest Dokka version (1.9.21)