### PR TITLE
Increase Gradle's max metaspace size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,5 @@ kotlinVersion=1.9.21
 dokkaVersion=1.9.10
 freemarkerVersion=2.3.29
 pluginPublishVersion=1.3.1
+
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1G


### PR DESCRIPTION
Knit loads tons of different classes
and in CI it exhausts metaspace from time to time.

Bumped up the metaspace size to prevent metaspace-induced CI failures.